### PR TITLE
fix: lspatch.jar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: SE Extended PrePatchs
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '45 11,23 * * *'
 
 jobs:
   Build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: SE Extended PrePatchs
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '45 11,23 * * *'
 
 jobs:
   Build:
@@ -57,7 +55,7 @@ jobs:
 
       - name: RENAMING APK FILE
         run: |
-          mv ./snapchat-402-lspatched.apk ./${{ env.VERSION }}-PrePatch.apk
+          mv ./snapchat-418-lspatched.apk ./${{ env.VERSION }}-PrePatch.apk
 
       - name: UPLOADING APK ARTIFACT
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Download & Install the latest release from ether [SE Extended PrePatch](https://
 To update the PrePatch simply Download & Update 
 
 ## 🙏 Credits
-- [LSPatch](https://github.com/LSPosed/LSPatch) (Used for Patching)
-- [APKMirror](https://www.apkmirror.com/) (Used to get snapchat apk)
+- [JingMatrix/LSPatch](https://github.com/JingMatrix/LSPatch) | Used for Patching)
+- [APKMirror](https://www.apkmirror.com/) | Used to get snapchat apk
 
 ## 📃 License
 Core.apk is under License GPL v3 Only


### PR DESCRIPTION
- uses JingMatrix/LSPatch since upsteam has been killed via new google play system update
- fixes snapchat crashing.